### PR TITLE
Fix minutes range condition in parse_from_hhmmss function

### DIFF
--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -77,7 +77,7 @@ impl Time {
                     .parse()
                     .map_err(|_| "Minutes string is not a number!")
                     .and_then(|m| {
-                        if m < 59 {
+                        if m < 60 {
                             Ok(m)
                         } else {
                             Err("Minutes is not in range 0-59")


### PR DESCRIPTION
This pull request addresses the issue reported in [Issue #5 ], where the `parse_from_hhmmss` function contains an incorrect condition for checking the range of minutes. The existing condition `m < 59` restricts the valid range of minutes, preventing the calculation of times with minutes ranging from 0 to 59. The correct condition should be `m < 60` to include minutes from 0 to 59.