### PR TITLE
Add support for MTK NMEA Packet Protocol and jamming detection status

### DIFF
--- a/src/mtk.rs
+++ b/src/mtk.rs
@@ -1,0 +1,89 @@
+use crate::Source;
+use core::convert::TryFrom;
+
+/// MTK NMEA packet type
+#[derive(Debug, PartialEq, Clone)]
+pub enum MTKPacketType {
+    /// Related to Spoofing and Jamming detection
+    SPF,
+}
+
+impl TryFrom<&str> for MTKPacketType {
+    type Error = &'static str;
+
+    fn try_from(from: &str) -> Result<Self, Self::Error> {
+        match from {
+            "SPF" => Ok(MTKPacketType::SPF),
+            _ => Err("Unsupported MTKPacketType."),
+        }
+    }
+}
+
+/// Related to Spoofing and Jamming detection .
+#[derive(Debug, PartialEq, Clone)]
+pub struct PMTKSPF {
+    /// Navigational system.
+    pub source: Source,
+    /// GPS Jamming status
+    pub jamming_status: JammingStatus,
+}
+
+impl PMTKSPF {
+    pub(crate) fn parse<'a>(
+        source: Source,
+        fields: &mut core::str::Split<'a, char>,
+    ) -> Result<Option<Self>, &'static str> {
+        let jamming_status = JammingStatus::parse(fields.next())?;
+        if let Some(jamming_status) = jamming_status {
+            Ok(Some(PMTKSPF {
+                source,
+                jamming_status,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+/// Status of gps Jamming
+#[derive(Debug, PartialEq, Clone,Copy)]
+pub enum JammingStatus {
+    /// No Jamming
+    Healthy,
+    /// Instantaneous jamming
+    Warning,
+    /// Continuous jamming
+    Critical,
+}
+
+impl JammingStatus {
+    pub(crate) fn parse(input: Option<&str>) -> Result<Option<JammingStatus>, &'static str> {
+        match input {
+            Some("1") => Ok(Some(JammingStatus::Healthy)),
+            Some("2") => Ok(Some(JammingStatus::Warning)),
+            Some("3") => Ok(Some(JammingStatus::Critical)),
+            Some("") => Ok(None),
+            None => Ok(None),
+            _ => Err("Wrong JammingStatus indicator type!"),
+        }
+    }
+}
+
+#[test]
+fn test_parse_jammingstatus() {
+    assert_eq!(
+        JammingStatus::parse(Some("1")),
+        Ok(Some(JammingStatus::Healthy))
+    );
+    assert_eq!(
+        JammingStatus::parse(Some("2")),
+        Ok(Some(JammingStatus::Warning))
+    );
+    assert_eq!(
+        JammingStatus::parse(Some("3")),
+        Ok(Some(JammingStatus::Critical))
+    );
+    assert_eq!(JammingStatus::parse(Some("")), Ok(None));
+    assert_eq!(JammingStatus::parse(None), Ok(None));
+    assert!(JammingStatus::parse(Some("0")).is_err());
+}

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -2,9 +2,11 @@ use core::convert::TryFrom;
 use nmea0183::coords;
 use nmea0183::datetime;
 use nmea0183::GPSQuality;
+use nmea0183::JammingStatus;
 use nmea0183::Mode;
 use nmea0183::GGA;
 use nmea0183::GLL;
+use nmea0183::PMTKSPF;
 use nmea0183::RMC;
 use nmea0183::VTG;
 use nmea0183::{ParseResult, Parser, Source};
@@ -19,8 +21,8 @@ fn test_too_long_sentence() {
             Err("NMEA sentence is too long!") => {
                 caught_error = true;
                 break;
-            },
-            Err(_) => panic!("Unexpected error caught in test!")
+            }
+            Err(_) => panic!("Unexpected error caught in test!"),
         }
     }
     assert!(caught_error);
@@ -238,6 +240,22 @@ fn test_correct_gll() {
                 latitude: TryFrom::try_from(49.2741666667).unwrap(),
                 longitude: TryFrom::try_from(-123.18533333334).unwrap(),
                 mode: Mode::Autonomous
+            })))
+        );
+    }
+}
+
+#[test]
+fn test_correct_pmtk() {
+    let mut p = Parser::new();
+    let b = b"$PMTKSPF,2*59\r\n";
+    {
+        let mut iter = p.parse_from_bytes(&b[..]);
+        assert_eq!(
+            iter.next().unwrap(),
+            Ok(ParseResult::PMTK(Some(PMTKSPF {
+                source: Source::MTK,
+                jamming_status: JammingStatus::Warning
             })))
         );
     }


### PR DESCRIPTION
**Description:**
This pull request introduces support for the MTK NMEA Packet Protocol and includes the necessary changes to retrieve and parse jamming detection status using the $PMTKSPF sentence.

**Changes Made:**

**New Functionality:**
- Implemented parsing logic for MTK-specific NMEA sentences.
- Added support for the $PMTKSPF sentence to extract jamming detection status information.

**Modifications:**
- Modified existing parsing functions to accommodate the MTK NMEA Packet Protocol.

**Why These Changes Are Necessary:**
The current version of the nmea0183 parser  lacks support for the MTK NMEA Packet Protocol, specifically the $PMTKSPF sentence, which provides crucial information about jamming detection status. This enhancement is necessary for users relying on MTK-based GPS modules to access comprehensive satellite signal integrity data.

**Benefits:**
1. **Enhanced Compatibility:**
   - Users employing MTK-based GPS modules will benefit from enhanced compatibility with the parser, ensuring accurate parsing of MTK-specific NMEA sentences.
2. **Jamming Detection Status:**
   - The addition of $PMTKSPF support allows users to retrieve jamming detection status, providing valuable information about potential signal interference.

**Testing Done:**
Thoroughly tested the changes with sample data and verified that the parser correctly handles MTK NMEA sentences, including the $PMTKSPF sentence.

**Contributor Checklist:**
- [x] Code follows the project's coding standards.
- [x] New tests added for the introduced functionality.
- [x] Documentation updated to reflect the changes.

**Related Issues:**
Closes #7 (if applicable)
