### PR TITLE
Add GSV Sentence Parsing Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Codecov coverage status](https://codecov.io/gh/nsforth/nmea0183/branch/master/graph/badge.svg)](https://codecov.io/gh/nsforth/nmea0183)
 # NMEA 0183 parser.
 
-Implemented most used sentences like RMC, VTG, GGA, GLL.
+Implemented most used sentences like RMC, VTG, GGA, GLL, GSV.
 Parser do not use heap memory and relies only on `core`.
 
 You should instantiate [Parser](https://docs.rs/nmea0183/latest/nmea0183/struct.Parser.html) with [new](https://docs.rs/nmea0183/latest/nmea0183/struct.Parser.html#method.new) and than use methods like [parse_from_byte](https://docs.rs/nmea0183/latest/nmea0183/struct.Parser.html#method.parse_from_bytes) or [parse_from_bytes](https://docs.rs/nmea0183/latest/nmea0183/struct.Parser.html#method.parse_from_bytes).
@@ -77,5 +77,5 @@ It's possible to got other very rare error messages that relates to protocol err
 
 # Planned features
 
-GSA and GSV parsing.
+GSA parsing.
 

--- a/src/gsv.rs
+++ b/src/gsv.rs
@@ -5,6 +5,8 @@ const MAX_SATELLITES_PER_MESSAGE: usize = 4;
 /// Satellites in views including the number of SVs in view, the PRN numbers, elevations, azimuths, and SNR values.
 #[derive(Debug, PartialEq, Clone)]
 pub struct GSV {
+    /// Navigational system.
+    pub source: Source,
     /// The total number of GSV messages for the current data.
     pub total_messages_number: u8,
     /// The message number (1 to the total number of messages) for the current GSV sentence.
@@ -29,7 +31,7 @@ impl GSV {
         let mut satellite_array_size = 0;
 
         for satellite in satellites.iter_mut() {
-            if let Some(parsed_satellite) = Satellite::parse(fields, source)? {
+            if let Some(parsed_satellite) = Satellite::parse(fields)? {
                 *satellite = parsed_satellite;
                 satellite_array_size += 1;
             } else {
@@ -41,6 +43,7 @@ impl GSV {
             (total_messages_number, message_number, sat_in_view)
         {
             Ok(Some(GSV {
+                source,
                 total_messages_number,
                 message_number,
                 sat_in_view,

--- a/src/gsv.rs
+++ b/src/gsv.rs
@@ -1,0 +1,66 @@
+use crate::common;
+use crate::satellite::Satellite;
+
+use crate::Source;
+/// Satellites in views including the number of SVs in view, the PRN numbers, elevations, azimuths, and SNR values.
+#[derive(Debug, PartialEq, Clone)]
+pub struct GSV {
+    /// The total number of GSV messages for the current data.
+    pub total_messages_number: u8,
+    /// The message number (1 to the total number of messages) for the current GSV sentence.
+    pub message_number: u8,
+    /// Total number of satellites in view.
+    pub sat_in_view: u8,
+    /// Information about first SV.
+    pub sat_info_1: Option<Satellite>,
+    /// Information about second SV.
+    pub sat_info_2: Option<Satellite>,
+    /// Information about third SV.
+    pub sat_info_3: Option<Satellite>,
+    /// Information about fourth SV.
+    pub sat_info_4: Option<Satellite>,
+}
+
+impl GSV {
+    pub(crate) fn parse<'a>(
+        source: Source,
+        fields: &mut core::str::Split<'a, char>,
+    ) -> Result<Option<Self>, &'static str> {
+        let total_messages_number = common::parse_u8(fields.next())?;
+        let message_number = common::parse_u8(fields.next())?;
+        let sat_in_view = common::parse_u8(fields.next())?;
+        let mut sat_info_1 = None;
+        let mut sat_info_2 = None;
+        let mut sat_info_3 = None;
+        let mut sat_info_4 = None;
+        for sat_num in 1..=4 {
+            if let Some(sat_info) = Satellite::parse(fields, source)? {
+                match sat_num {
+                    1 => sat_info_1 = Some(sat_info),
+                    2 => sat_info_2 = Some(sat_info),
+                    3 => sat_info_3 = Some(sat_info),
+                    4 => sat_info_4 = Some(sat_info),
+                    _ => unreachable!(),
+                }
+            } else {
+                break;
+            }
+        }
+
+        if let (Some(total_messages_number), Some(message_number), Some(sat_in_view)) =
+            (total_messages_number, message_number, sat_in_view)
+        {
+            Ok(Some(GSV {
+                total_messages_number,
+                message_number,
+                sat_in_view,
+                sat_info_1,
+                sat_info_2,
+                sat_info_3,
+                sat_info_4,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/src/gsv.rs
+++ b/src/gsv.rs
@@ -54,8 +54,8 @@ impl GSV {
             Ok(None)
         }
     }
-    /// Retrieves a slice containing the valid satellite information present in the GSV message.
-    pub fn get_satellites(&self) -> &[Satellite] {
+    /// Retrieves a slice containing in view satellites information present in the GSV message.
+    pub fn get_in_view_satellites(&self) -> &[Satellite] {
         &self.satellites[..self.satellite_array_size]
     }
 }

--- a/src/gsv.rs
+++ b/src/gsv.rs
@@ -1,7 +1,7 @@
 use crate::common;
 use crate::satellite::Satellite;
-
 use crate::Source;
+const MAX_SATELLITES_PER_MESSAGE: usize = 4;
 /// Satellites in views including the number of SVs in view, the PRN numbers, elevations, azimuths, and SNR values.
 #[derive(Debug, PartialEq, Clone)]
 pub struct GSV {
@@ -11,14 +11,10 @@ pub struct GSV {
     pub message_number: u8,
     /// Total number of satellites in view.
     pub sat_in_view: u8,
-    /// Information about first SV.
-    pub sat_info_1: Option<Satellite>,
-    /// Information about second SV.
-    pub sat_info_2: Option<Satellite>,
-    /// Information about third SV.
-    pub sat_info_3: Option<Satellite>,
-    /// Information about fourth SV.
-    pub sat_info_4: Option<Satellite>,
+    /// Array of satellite information.
+    satellites: [Satellite; MAX_SATELLITES_PER_MESSAGE],
+    /// The actual number of satellites in the array.
+    satellite_array_size: usize,
 }
 
 impl GSV {
@@ -29,19 +25,13 @@ impl GSV {
         let total_messages_number = common::parse_u8(fields.next())?;
         let message_number = common::parse_u8(fields.next())?;
         let sat_in_view = common::parse_u8(fields.next())?;
-        let mut sat_info_1 = None;
-        let mut sat_info_2 = None;
-        let mut sat_info_3 = None;
-        let mut sat_info_4 = None;
-        for sat_num in 1..=4 {
-            if let Some(sat_info) = Satellite::parse(fields, source)? {
-                match sat_num {
-                    1 => sat_info_1 = Some(sat_info),
-                    2 => sat_info_2 = Some(sat_info),
-                    3 => sat_info_3 = Some(sat_info),
-                    4 => sat_info_4 = Some(sat_info),
-                    _ => unreachable!(),
-                }
+        let mut satellites: [Satellite; MAX_SATELLITES_PER_MESSAGE] = Default::default();
+        let mut satellite_array_size = 0;
+
+        for satellite in satellites.iter_mut() {
+            if let Some(parsed_satellite) = Satellite::parse(fields, source)? {
+                *satellite = parsed_satellite;
+                satellite_array_size += 1;
             } else {
                 break;
             }
@@ -54,13 +44,15 @@ impl GSV {
                 total_messages_number,
                 message_number,
                 sat_in_view,
-                sat_info_1,
-                sat_info_2,
-                sat_info_3,
-                sat_info_4,
+                satellites,
+                satellite_array_size,
             }))
         } else {
             Ok(None)
         }
+    }
+    /// Retrieves a slice containing the valid satellite information present in the GSV message.
+    pub fn get_satellites(&self) -> &[Satellite] {
+        &self.satellites[..self.satellite_array_size]
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,11 @@ use core::slice::Iter;
 pub(crate) mod common;
 pub mod coords;
 pub mod datetime;
+pub mod satellite;
+
 pub(crate) mod gga;
+pub(crate) mod gsv;
+
 pub(crate) mod gll;
 pub(crate) mod modes;
 pub(crate) mod rmc;
@@ -92,10 +96,10 @@ pub(crate) mod vtg;
 pub use gga::GPSQuality;
 pub use gga::GGA;
 pub use gll::GLL;
+pub use gsv::GSV;
 pub use modes::Mode;
 pub use rmc::RMC;
 pub use vtg::VTG;
-
 /// Source of NMEA sentence like GPS, GLONASS or other.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Source {
@@ -174,6 +178,8 @@ pub enum Sentence {
     GGA = 0b100,
     /// Geographic latitude ang longitude sentence with time of fix and receiver state.
     GLL = 0b1000,
+    /// Satellites in views.
+    GSV = 0b10000,
 }
 
 impl TryFrom<&str> for Sentence {
@@ -185,6 +191,7 @@ impl TryFrom<&str> for Sentence {
             "GGA" => Ok(Sentence::GGA),
             "GLL" => Ok(Sentence::GLL),
             "VTG" => Ok(Sentence::VTG),
+            "GSV" => Ok(Sentence::GSV),
             _ => Err("Unsupported sentence type."),
         }
     }
@@ -240,6 +247,8 @@ pub enum ParseResult {
     GLL(Option<GLL>),
     /// The actual course and speed relative to the ground.
     VTG(Option<VTG>),
+    /// The satellites in views including the number of SVs in view, the PRN numbers, elevations, azimuths, and SNR values.
+    GSV(Option<GSV>),
 }
 
 /// Parses NMEA sentences and stores intermediate parsing state.
@@ -408,6 +417,7 @@ impl Parser {
             Sentence::GGA => Ok(Some(ParseResult::GGA(GGA::parse(source, &mut iter)?))),
             Sentence::GLL => Ok(Some(ParseResult::GLL(GLL::parse(source, &mut iter)?))),
             Sentence::VTG => Ok(Some(ParseResult::VTG(VTG::parse(source, &mut iter)?))),
+            Sentence::GSV => Ok(Some(ParseResult::GSV(GSV::parse(source, &mut iter)?))),
         }
     }
 }

--- a/src/satellite.rs
+++ b/src/satellite.rs
@@ -1,13 +1,12 @@
 //! Structures that describe satellites in views .
 
 use crate::common;
-use crate::Source;
 
 ///Information about satellite in view.
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct Satellite {
     /// Satellite pseudo-random noise number.
-    pub prn: Prn,
+    pub prn: u16,
     /// Angle of elevation of the satellite above the horizontal plane in degrees, 90° maximum.
     pub elevation: u8,
     /// Degrees from True North, 000° through 359°
@@ -19,9 +18,8 @@ pub struct Satellite {
 impl Satellite {
     pub(crate) fn parse<'a>(
         fields: &mut core::str::Split<'a, char>,
-        source: Source,
     ) -> Result<Option<Self>, &'static str> {
-        let prn = Prn::parse(fields.next(), source)?;
+        let prn = common::parse_u16(fields.next())?;
         let elevation = common::parse_u8(fields.next())?;
         let azimuth = common::parse_u16(fields.next())?;
         let snr = common::parse_u8(fields.next())?;
@@ -33,38 +31,6 @@ impl Satellite {
                 azimuth,
                 snr,
             }))
-        } else {
-            Ok(None)
-        }
-    }
-}
-
-///Satellite pseudo-random noise number
-#[derive(Debug, PartialEq, Clone, Default)]
-pub struct Prn {
-    /// Satellite pseudo-random noise number based on source of NMEA sentence
-    pub number: u8,
-}
-
-impl Prn {
-    pub(crate) fn parse(input: Option<&str>, source: Source) -> Result<Option<Self>, &'static str> {
-        if let Some(input) = input {
-            if input.len() == 0 {
-                Ok(None)
-            } else {
-                let original_prn_number =
-                    input.parse::<u8>().map_err(|_| "Wrong prn field format")?;
-
-                let adjusted_prn_number = match source {
-                    Source::Beidou => original_prn_number.checked_sub(100),
-                    Source::GLONASS => original_prn_number.checked_sub(64),
-                    _ => Some(original_prn_number),
-                };
-                match adjusted_prn_number {
-                    Some(number) => Ok(Some(Prn { number })),
-                    None => Err("Could not parse Prn: number not match GNSS system Prn range"),
-                }
-            }
         } else {
             Ok(None)
         }

--- a/src/satellite.rs
+++ b/src/satellite.rs
@@ -62,7 +62,7 @@ impl Prn {
                 };
                 match adjusted_prn_number {
                     Some(number) => Ok(Some(Prn { number })),
-                    None => Err("Could not parse prn"),
+                    None => Err("Could not parse Prn: number not match GNSS system Prn range"),
                 }
             }
         } else {

--- a/src/satellite.rs
+++ b/src/satellite.rs
@@ -4,7 +4,7 @@ use crate::common;
 use crate::Source;
 
 ///Information about satellite in view.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Default)]
 pub struct Satellite {
     /// Satellite pseudo-random noise number.
     pub prn: Prn,
@@ -40,7 +40,7 @@ impl Satellite {
 }
 
 ///Satellite pseudo-random noise number
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Default)]
 pub struct Prn {
     /// Satellite pseudo-random noise number based on source of NMEA sentence
     pub number: u8,

--- a/src/satellite.rs
+++ b/src/satellite.rs
@@ -43,7 +43,7 @@ impl Satellite {
 #[derive(Debug, PartialEq, Clone)]
 pub struct Prn {
     /// Satellite pseudo-random noise number based on source of NMEA sentence
-    pub numbers: u8,
+    pub number: u8,
 }
 
 impl Prn {
@@ -52,16 +52,16 @@ impl Prn {
             if input.len() == 0 {
                 Ok(None)
             } else {
-                let original_prn_numbers =
+                let original_prn_number =
                     input.parse::<u8>().map_err(|_| "Wrong prn field format")?;
 
-                let adjusted_prn_numbers = match source {
-                    Source::Beidou => original_prn_numbers.checked_sub(100),
-                    Source::GLONASS => original_prn_numbers.checked_sub(64),
-                    _ => Some(original_prn_numbers),
+                let adjusted_prn_number = match source {
+                    Source::Beidou => original_prn_number.checked_sub(100),
+                    Source::GLONASS => original_prn_number.checked_sub(64),
+                    _ => Some(original_prn_number),
                 };
-                match adjusted_prn_numbers {
-                    Some(numbers) => Ok(Some(Prn { numbers })),
+                match adjusted_prn_number {
+                    Some(number) => Ok(Some(Prn { number })),
                     None => Err("Could not parse prn"),
                 }
             }

--- a/src/satellite.rs
+++ b/src/satellite.rs
@@ -1,0 +1,72 @@
+//! Structures that describe satellites in views .
+
+use crate::common;
+use crate::Source;
+
+///Information about satellite in view.
+#[derive(Debug, PartialEq, Clone)]
+pub struct Satellite {
+    /// Satellite pseudo-random noise number.
+    pub prn: Prn,
+    /// Angle of elevation of the satellite above the horizontal plane in degrees, 90° maximum.
+    pub elevation: u8,
+    /// Degrees from True North, 000° through 359°
+    pub azimuth: u16,
+    /// Signal-to-Noise Ratio . 00 through 99 dB (null when not tracking) .
+    pub snr: Option<u8>,
+}
+
+impl Satellite {
+    pub(crate) fn parse<'a>(
+        fields: &mut core::str::Split<'a, char>,
+        source: Source,
+    ) -> Result<Option<Self>, &'static str> {
+        let prn = Prn::parse(fields.next(), source)?;
+        let elevation = common::parse_u8(fields.next())?;
+        let azimuth = common::parse_u16(fields.next())?;
+        let snr = common::parse_u8(fields.next())?;
+
+        if let (Some(prn), Some(elevation), Some(azimuth)) = (prn, elevation, azimuth) {
+            Ok(Some(Self {
+                prn,
+                elevation,
+                azimuth,
+                snr,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+///Satellite pseudo-random noise number
+#[derive(Debug, PartialEq, Clone)]
+pub struct Prn {
+    /// Satellite pseudo-random noise number based on source of NMEA sentence
+    pub numbers: u8,
+}
+
+impl Prn {
+    pub(crate) fn parse(input: Option<&str>, source: Source) -> Result<Option<Self>, &'static str> {
+        if let Some(input) = input {
+            if input.len() == 0 {
+                Ok(None)
+            } else {
+                let original_prn_numbers =
+                    input.parse::<u8>().map_err(|_| "Wrong prn field format")?;
+
+                let adjusted_prn_numbers = match source {
+                    Source::Beidou => original_prn_numbers.checked_sub(100),
+                    Source::GLONASS => original_prn_numbers.checked_sub(64),
+                    _ => Some(original_prn_numbers),
+                };
+                match adjusted_prn_numbers {
+                    Some(numbers) => Ok(Some(Prn { numbers })),
+                    None => Err("Could not parse prn"),
+                }
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -257,25 +257,25 @@ fn test_correct_gsv() {
                 message_number: 1,
                 sat_in_view: 25,
                 sat_info_1: Some(satellite::Satellite {
-                    prn: satellite::Prn { numbers: 21 },
+                    prn: satellite::Prn { number: 21 },
                     elevation: 44,
                     azimuth: 141,
                     snr: Some(47)
                 }),
                 sat_info_2: Some(satellite::Satellite {
-                    prn: satellite::Prn { numbers: 15 },
+                    prn: satellite::Prn { number: 15 },
                     elevation: 14,
                     azimuth: 49,
                     snr: Some(44)
                 }),
                 sat_info_3: Some(satellite::Satellite {
-                    prn: satellite::Prn { numbers: 6 },
+                    prn: satellite::Prn { number: 6 },
                     elevation: 31,
                     azimuth: 255,
                     snr: Some(46)
                 }),
                 sat_info_4: Some(satellite::Satellite {
-                    prn: satellite::Prn { numbers: 3 },
+                    prn: satellite::Prn { number: 3 },
                     elevation: 25,
                     azimuth: 280,
                     snr: Some(44)
@@ -298,7 +298,7 @@ fn test_correct_gsv2() {
                 message_number: 7,
                 sat_in_view: 25,
                 sat_info_1: Some(satellite::Satellite {
-                    prn: satellite::Prn { numbers: 4 },
+                    prn: satellite::Prn { number: 4 },
                     elevation: 37,
                     azimuth: 284,
                     snr: Some(50)

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -257,6 +257,7 @@ fn test_correct_gsv() {
                 panic!("Unexpected ParseResult variant while parsing GSV data.");
             }
         };
+        assert_eq!(gsv.source, Source::GPS);
         assert_eq!(gsv.total_messages_number, 8);
         assert_eq!(gsv.message_number, 1);
         assert_eq!(gsv.sat_in_view, 25);
@@ -265,25 +266,25 @@ fn test_correct_gsv() {
             gsv.get_satellites(),
             [
                 satellite::Satellite {
-                    prn: satellite::Prn { number: 21 },
+                    prn: 21,
                     elevation: 44,
                     azimuth: 141,
                     snr: Some(47)
                 },
                 satellite::Satellite {
-                    prn: satellite::Prn { number: 15 },
+                    prn: 15,
                     elevation: 14,
                     azimuth: 49,
                     snr: Some(44)
                 },
                 satellite::Satellite {
-                    prn: satellite::Prn { number: 6 },
+                    prn: 6,
                     elevation: 31,
                     azimuth: 255,
                     snr: Some(46)
                 },
                 satellite::Satellite {
-                    prn: satellite::Prn { number: 3 },
+                    prn: 3,
                     elevation: 25,
                     azimuth: 280,
                     snr: Some(44)
@@ -305,6 +306,7 @@ fn test_correct_gsv2() {
                 panic!("Unexpected ParseResult variant while parsing GSV data.");
             }
         };
+        assert_eq!(gsv.source, Source::GLONASS);
         assert_eq!(gsv.total_messages_number, 8);
         assert_eq!(gsv.message_number, 7);
         assert_eq!(gsv.sat_in_view, 25);
@@ -312,13 +314,13 @@ fn test_correct_gsv2() {
         assert_eq!(
             gsv.get_satellites(),
             [satellite::Satellite {
-                prn: satellite::Prn { number: 4 },
+                prn: 68,
                 elevation: 37,
                 azimuth: 284,
                 snr: Some(50)
             },],
         )
-  }
+    }
 }
 #[test]
 fn test_correct_pmtk() {

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -263,7 +263,7 @@ fn test_correct_gsv() {
         assert_eq!(gsv.sat_in_view, 25);
 
         assert_eq!(
-            gsv.get_satellites(),
+            gsv.get_in_view_satellites(),
             [
                 satellite::Satellite {
                     prn: 21,
@@ -312,7 +312,7 @@ fn test_correct_gsv2() {
         assert_eq!(gsv.sat_in_view, 25);
 
         assert_eq!(
-            gsv.get_satellites(),
+            gsv.get_in_view_satellites(),
             [satellite::Satellite {
                 prn: 68,
                 elevation: 37,


### PR DESCRIPTION
## Description

This pull request adds support for parsing GSV (Satellites in View) sentences to the nmea0183 Rust crate. The GSV sentence provides information about the satellites in view .

## Changes Made

- Added a new module for GSV parsing.
- Implemented GSV sentence parsing logic.
- Updated documentation to include information about GSV support.
- Added relevant test cases to ensure the correctness of the implementation.

## Context

Currently, the nmea0183 crate supports RMC, VTG, GGA, and GLL sentences. However, GSV sentences are essential for applications that require detailed information about visible satellites. This addition enhances the functionality of the crate and broadens its use cases.

## Testing

Tested the implementation with sample NMEA sentences containing GSV data. All relevant tests pass successfully.

## Related Issues

Closes #9 

## Checklist

- [x] Code follows the project's coding standards.
- [x] Updated or added relevant documentation.
- [x] Tests for the new functionality are added and pass.

Please review and merge at your earliest convenience. I am open to feedback and happy to make any necessary changes.
