### PR TITLE
Add handling for ZDA-Sentence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.vscode

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,14 @@
+pub(crate) fn parse_i8(input: Option<&str>) -> Result<Option<i8>, &'static str> {
+    match input {
+        Some(s) if s.len() == 0 => Ok(None),
+        Some(s) => s
+            .parse::<i8>()
+            .map_err(|_| "Wrong signed int field format")
+            .and_then(|u| Ok(Some(u))),
+        None => Ok(None),
+    }
+}
+
 pub(crate) fn parse_u8(input: Option<&str>) -> Result<Option<u8>, &'static str> {
     match input {
         Some(s) if s.len() == 0 => Ok(None),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ pub(crate) mod modes;
 pub(crate) mod mtk;
 pub(crate) mod rmc;
 pub(crate) mod vtg;
+pub(crate) mod zda;
 
 pub use gga::GPSQuality;
 pub use gga::GGA;
@@ -111,6 +112,8 @@ pub use mtk::MTKPacketType;
 pub use mtk::PMTKSPF;
 pub use rmc::RMC;
 pub use vtg::VTG;
+pub use zda::ZDA;
+
 /// Source of NMEA sentence like GPS, GLONASS or other.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Source {
@@ -201,6 +204,8 @@ pub enum Sentence {
     GSV = 0b100000,
     /// GPS DOP and active satellites.
     GSA = 0b1000000,
+    /// Current Date and Time.
+    ZDA = 0b10000000,
 }
 
 impl TryFrom<&str> for Sentence {
@@ -216,6 +221,8 @@ impl TryFrom<&str> for Sentence {
             #[cfg(feature = "mtk")]
             "PMTK" => Ok(Sentence::PMTK),
             "GSA" => Ok(Sentence::GSA),
+            "ZDA" => Ok(Sentence::ZDA),
+
             _ => Err("Unsupported sentence type."),
         }
     }
@@ -278,6 +285,8 @@ pub enum ParseResult {
     PMTK(Option<PMTKSPF>),
     /// The GPS DOP and active satellites. Provides information about the DOP and the active satellites used for the current fix.
     GSA(Option<GSA>),
+    /// Current Date and Time.
+    ZDA(Option<ZDA>),
 }
 
 #[cfg(feature = "strict")]
@@ -462,6 +471,8 @@ impl Parser {
             Sentence::VTG => Ok(Some(ParseResult::VTG(VTG::parse(source, &mut iter)?))),
             Sentence::GSV => Ok(Some(ParseResult::GSV(GSV::parse(source, &mut iter)?))),
             Sentence::GSA => Ok(Some(ParseResult::GSA(GSA::parse(source, &mut iter)?))),
+            Sentence::ZDA => Ok(Some(ParseResult::ZDA(ZDA::parse(source, &mut iter)?))),
+
             #[cfg(feature = "mtk")]
             Sentence::PMTK => {
                 if sentence_field.len() < 7 {

--- a/src/zda.rs
+++ b/src/zda.rs
@@ -1,0 +1,51 @@
+use crate::datetime::{Date, Time};
+use crate::{common, Source};
+
+/// Geographic latitude ang longitude sentence with time of fix and receiver state.
+#[derive(Debug, PartialEq, Clone)]
+pub struct ZDA {
+    /// Navigational system.
+    pub source: Source,
+    /// Current Time  in UTC.
+    pub time: Time,
+    /// Current Day
+    pub day: u8,
+    /// Current Month
+    pub month: u8,
+    /// Current Year
+    pub year: u16,
+    /// Offset in hours from UTC.
+    pub offset_hours: Option<i8>,
+    /// Offset in minutes from UTC,
+    pub offset_minutes: Option<u8>,
+}
+
+impl ZDA {
+    pub(crate) fn parse<'a>(
+        source: Source,
+        fields: &mut core::str::Split<'a, char>,
+    ) -> Result<Option<Self>, &'static str> {
+        let time = Time::parse_from_hhmmss(fields.next())?;
+        let day = common::parse_u8(fields.next())?;
+        let month = common::parse_u8(fields.next())?;
+        let year = common::parse_u16(fields.next())?;
+        let offset_hours = common::parse_i8(fields.next())?;
+        let offset_minutes = common::parse_u8(fields.next())?;
+
+        if let (Some(time), Some(day), Some(month), Some(year), offset_hours, offset_minutes) =
+            (time, day, month, year, offset_hours, offset_minutes)
+        {
+            Ok(Some(ZDA {
+                source,
+                time,
+                day,
+                month,
+                year,
+                offset_hours,
+                offset_minutes,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -430,6 +430,64 @@ fn test_correct_gsa() {
 }
 
 #[test]
+fn test_correct_zda() {
+    let mut p = Parser::new();
+    let b = b"$GNZDA,181604.456,12,09,2018,-01,15*6C\r\n";
+    {
+        let mut iter = p.parse_from_bytes(&b[..]);
+        let zda = match iter.next().unwrap().unwrap() {
+            ParseResult::ZDA(Some(zda)) => zda,
+            _ => {
+                panic!("Unexpected ParseResult variant while parsing GSA data.");
+            }
+        };
+        assert_eq!(zda.source, Source::GNSS);
+        assert_eq!(
+            zda.time,
+            datetime::Time {
+                hours: 18,
+                minutes: 16,
+                seconds: 04.456
+            }
+        );
+        assert_eq!(zda.day, 12);
+        assert_eq!(zda.month, 9);
+        assert_eq!(zda.year, 2018);
+        assert_eq!(zda.offset_hours, Some(-1));
+        assert_eq!(zda.offset_minutes, Some(15));
+    }
+}
+
+#[test]
+fn test_correct_zda_2() {
+    let mut p = Parser::new();
+    let b = b"$GNZDA,181604.456,12,09,2018,,*44\r\n";
+    {
+        let mut iter = p.parse_from_bytes(&b[..]);
+        let zda = match iter.next().unwrap().unwrap() {
+            ParseResult::ZDA(Some(zda)) => zda,
+            _ => {
+                panic!("Unexpected ParseResult variant while parsing GSA data.");
+            }
+        };
+        assert_eq!(zda.source, Source::GNSS);
+        assert_eq!(
+            zda.time,
+            datetime::Time {
+                hours: 18,
+                minutes: 16,
+                seconds: 04.456
+            }
+        );
+        assert_eq!(zda.day, 12);
+        assert_eq!(zda.month, 9);
+        assert_eq!(zda.year, 2018);
+        assert_eq!(zda.offset_hours, None);
+        assert_eq!(zda.offset_minutes, None);
+    }
+}
+
+#[test]
 fn test_parser_iterator() {
     let mut p = Parser::new();
     let b = b"$GPRMC,125504.049,A,5542.2389,N,03741.6063,E,0.06,25.82,200906,,,A*56\r\n";


### PR DESCRIPTION
Add handling of ZDA-Sentence (Date, Time and UTC-Offset).
for example
"$GNZDA,181604.456,12,09,2018,-01,15*6C"
and
"$GNZDA,181604.456,12,09,2018,,*44" 

including test-cases
