### PR TITLE
Fix build of tests without default features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build
         run: cargo build --verbose
+      - name: Run tests without default features
+        run: cargo test --no-default-features
       - name: Run tests strict
         run: cargo test --no-default-features -F mtk,strict
       - name: Run tests non strict
         run: cargo test --no-default-features -F mtk
+      - name: Run tests with default features
+        run: cargo test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,8 @@
-name: master
+name: Rust
 
 on:
   push:
-    branches: ["master"]
   pull_request:
-    branches: ["master"]
 
 env:
   CARGO_TERM_COLOR: always

--- a/tests/parsing.rs
+++ b/tests/parsing.rs
@@ -7,10 +7,12 @@ use nmea0183::datetime;
 use nmea0183::satellite;
 use nmea0183::FixType;
 use nmea0183::GPSQuality;
+#[cfg(feature = "mtk")]
 use nmea0183::JammingStatus;
 use nmea0183::Mode;
 use nmea0183::GGA;
 use nmea0183::GLL;
+#[cfg(feature = "mtk")]
 use nmea0183::PMTKSPF;
 use nmea0183::RMC;
 use nmea0183::VTG;
@@ -391,7 +393,9 @@ fn test_correct_gsv2() {
         )
     }
 }
+
 #[test]
+#[cfg(feature = "mtk")]
 fn test_correct_pmtk() {
     let mut p = Parser::new();
     let b = b"$PMTKSPF,2*59\r\n";


### PR DESCRIPTION
When running `cargo test --no-default-features`, the build was failing because some imports needed to be behind the feature `mtk`.

In CI I also added the run of tests with and without default features, to make sure tests always under any condition.