### PR TITLE
add support for defmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nmea0183"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Nikita Staroverov <nsforth@gmail.com>"]
 edition = "2018"
 description = "NMEA 0183 parser targetting mostly embedded devices but not limited to."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,13 @@ categories = ["embedded", "no-std", "parser-implementations"]
 readme = "README.md"
 
 [dependencies]
+defmt = { version = "1.0.1", optional = true }
 
 [features]
 default = ["strict"]
 mtk = []
 strict = []
+defmt = ["dep:defmt"]
 
 [badges]
 travis-ci = { repository = "nsforth/nmea0183", branch = "v0.5.0" }

--- a/src/coords.rs
+++ b/src/coords.rs
@@ -2,6 +2,7 @@
 use core::convert::TryFrom;
 
 /// Earth hemisphere
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub enum Hemisphere {
     /// North
@@ -15,6 +16,7 @@ pub enum Hemisphere {
 }
 
 /// Latitude as reported by receiver.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub struct Latitude {
     /// Degrees
@@ -121,6 +123,7 @@ impl Latitude {
 }
 
 /// Longitude as reported by receiver.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub struct Longitude {
     /// Degrees
@@ -227,6 +230,7 @@ impl Longitude {
 }
 
 /// Altitude reported by receiver typically in GGA sentence.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub struct Altitude {
     /// Altitude in meters over ground.
@@ -248,6 +252,7 @@ impl Altitude {
 }
 
 /// Speed reported by receiver typically in RMC and VTG sentences.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub struct Speed {
     knots: f32,
@@ -305,6 +310,7 @@ impl Speed {
 }
 
 /// The course over ground.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub struct Course {
     /// Course in degrees from North rotated clockwise.
@@ -331,6 +337,7 @@ impl Course {
 }
 
 /// The course over ground calculated from True course and magnetic variation.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub struct MagneticCourse {
     /// Course in degrees from Magnetic North Pole rotated clockwise.

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1,5 +1,6 @@
 //! NMEA date and time structures.
 /// NMEA date
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub struct Date {
     /// NMEA day
@@ -47,6 +48,7 @@ impl Date {
 }
 
 /// NMEA time in UTC
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub struct Time {
     /// Hours as reported by receiver
@@ -100,6 +102,7 @@ impl Time {
 }
 
 /// NMEA date and time in UTC
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub struct DateTime {
     /// NMEA date

--- a/src/gga.rs
+++ b/src/gga.rs
@@ -5,6 +5,7 @@ use crate::Source;
 use core::time::Duration;
 
 /// geographic coordinates including altitude, gps solution quality, dgps usage information
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub struct GGA {
     /// Navigational system.
@@ -99,29 +100,6 @@ pub enum GPSQuality {
     Manual,
     /// Simulated.
     Simulated,
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for GGA {
-    fn format(&self, f: defmt::Formatter) {
-        // format age_dgps as milliseconds to avoid formatting core::time::Duration directly
-        let age_ms: Option<u64> = self.age_dgps.map(|d| d.as_secs().saturating_mul(1000) + u64::from(d.subsec_millis()));
-        defmt::write!(
-            f,
-            "GGA {{ source: {}, time: {}, latitude: {}, longitude: {}, gps_quality: {}, sat_in_use: {}, hdop: {}, altitude: {}, geoidal_separation: {}, age_dgps_ms: {}, dgps_station_id: {} }}",
-            self.source,
-            self.time,
-            self.latitude,
-            self.longitude,
-            self.gps_quality,
-            self.sat_in_use,
-            self.hdop,
-            self.altitude,
-            self.geoidal_separation,
-            age_ms,
-            self.dgps_station_id
-        );
-    }
 }
 
 impl GPSQuality {

--- a/src/gga.rs
+++ b/src/gga.rs
@@ -4,7 +4,7 @@ use crate::datetime::Time;
 use crate::Source;
 use core::time::Duration;
 
-/// Geographic coordinates including altitude, GPS solution quality, DGPS usage information.
+/// geographic coordinates including altitude, gps solution quality, dgps usage information
 #[derive(Debug, PartialEq, Clone)]
 pub struct GGA {
     /// Navigational system.
@@ -77,7 +77,8 @@ impl GGA {
     }
 }
 
-/// Quality of GPS solution
+/// quality of gps solution
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub enum GPSQuality {
     /// No solution
@@ -98,6 +99,29 @@ pub enum GPSQuality {
     Manual,
     /// Simulated.
     Simulated,
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for GGA {
+    fn format(&self, f: defmt::Formatter) {
+        // format age_dgps as milliseconds to avoid formatting core::time::Duration directly
+        let age_ms: Option<u64> = self.age_dgps.map(|d| d.as_secs().saturating_mul(1000) + u64::from(d.subsec_millis()));
+        defmt::write!(
+            f,
+            "GGA {{ source: {}, time: {}, latitude: {}, longitude: {}, gps_quality: {}, sat_in_use: {}, hdop: {}, altitude: {}, geoidal_separation: {}, age_dgps_ms: {}, dgps_station_id: {} }}",
+            self.source,
+            self.time,
+            self.latitude,
+            self.longitude,
+            self.gps_quality,
+            self.sat_in_use,
+            self.hdop,
+            self.altitude,
+            self.geoidal_separation,
+            age_ms,
+            self.dgps_station_id
+        );
+    }
 }
 
 impl GPSQuality {

--- a/src/gll.rs
+++ b/src/gll.rs
@@ -3,7 +3,8 @@ use crate::datetime::Time;
 use crate::modes::{Mode, Status};
 use crate::Source;
 
-/// Geographic latitude ang longitude sentence with time of fix and receiver state.
+/// geographic latitude ang longitude sentence with time of fix and receiver state
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub struct GLL {
     /// Navigational system.

--- a/src/gsa.rs
+++ b/src/gsa.rs
@@ -3,7 +3,8 @@ use crate::modes::Mode;
 use crate::Source;
 const MAX_PRNS_PER_MESSAGE: usize = 12;
 
-/// GPS DOP and active satellites
+/// gps dop and active satellites
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub struct GSA {
     /// Navigational system.
@@ -64,7 +65,8 @@ impl GSA {
     }
 }
 
-/// Receiver mode of positioning.
+/// receiver mode of positioning
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub enum FixType {
     /// No valid position is available.

--- a/src/gsv.rs
+++ b/src/gsv.rs
@@ -3,6 +3,7 @@ use crate::satellite::Satellite;
 use crate::Source;
 const MAX_SATELLITES_PER_MESSAGE: usize = 4;
 /// Satellites in views including the number of SVs in view, the PRN numbers, elevations, azimuths, and SNR values.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub struct GSV {
     /// Navigational system.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,8 @@ pub use mtk::MTKPacketType;
 pub use mtk::PMTKSPF;
 pub use rmc::RMC;
 pub use vtg::VTG;
-/// Source of NMEA sentence like GPS, GLONASS or other.
+/// source of nmea sentence like gps, glonass or other
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Source {
     /// USA Global Positioning System
@@ -129,7 +130,8 @@ pub enum Source {
     MTK = 0b100000,
 }
 
-/// Mask for Source filter in Parser.
+/// mask for source filter in parser
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SourceMask {
     mask: u32,
 }
@@ -183,7 +185,8 @@ impl TryFrom<&str> for Source {
     }
 }
 
-/// Various kinds of NMEA sentence like RMC, VTG or other. Used for filter by sentence type in Parser.
+/// various kinds of nmea sentence like rmc, vtg or other. used for filter by sentence type in parser
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Copy, Clone)]
 pub enum Sentence {
     /// Recommended minimum sentence.
@@ -221,7 +224,8 @@ impl TryFrom<&str> for Sentence {
     }
 }
 
-/// Mask for Sentence filter in Parser.
+/// mask for sentence filter in parser
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SentenceMask {
     mask: u32,
 }
@@ -258,9 +262,8 @@ impl BitOr<Sentence> for SentenceMask {
     }
 }
 
-/// The NMEA sentence parsing result.
-/// Sentences with many null fields or sentences without valid data is also parsed and returned as None.
-/// None ParseResult may be interpreted as working receiver but without valid data.
+/// the nmea sentence parsing result. sentences with many null fields or sentences without valid data are parsed and returned as none. none can indicate working receiver without valid data
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub enum ParseResult {
     /// The Recommended Minimum Sentence for any GNSS. Typically most used.

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -1,3 +1,4 @@
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq)]
 pub(crate) enum Status {
     Valid,
@@ -14,7 +15,8 @@ impl Status {
     }
 }
 
-/// Receiver mode of operation.
+/// receiver mode of operation
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub enum Mode {
     /// Autonomous mode without any external correction.

--- a/src/mtk.rs
+++ b/src/mtk.rs
@@ -1,7 +1,8 @@
 use crate::Source;
 use core::convert::TryFrom;
 
-/// MTK NMEA packet type
+/// mtk nmea packet type
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub enum MTKPacketType {
     /// Related to Spoofing and Jamming detection
@@ -19,7 +20,8 @@ impl TryFrom<&str> for MTKPacketType {
     }
 }
 
-/// Related to Spoofing and Jamming detection .
+/// related to spoofing and jamming detection
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub struct PMTKSPF {
     /// Navigational system.
@@ -45,7 +47,8 @@ impl PMTKSPF {
     }
 }
 
-/// Status of gps Jamming
+/// status of gps jamming
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone,Copy)]
 pub enum JammingStatus {
     /// No Jamming

--- a/src/rmc.rs
+++ b/src/rmc.rs
@@ -3,7 +3,8 @@ use crate::datetime::{Date, DateTime, Time};
 use crate::modes::{Mode, Status};
 use crate::Source;
 
-/// Recommended Minimum Sentence for any GNSS source.
+/// recommended minimum sentence for any gnss source
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub struct RMC {
     /// Navigational system.

--- a/src/satellite.rs
+++ b/src/satellite.rs
@@ -2,7 +2,8 @@
 
 use crate::common;
 
-///Information about satellite in view.
+///information about satellite in view
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct Satellite {
     /// Satellite pseudo-random noise number.

--- a/src/vtg.rs
+++ b/src/vtg.rs
@@ -2,7 +2,8 @@ use crate::coords::{Course, MagneticCourse, Speed};
 use crate::modes::Mode;
 use crate::Source;
 
-/// The actual course and speed relative to the ground.
+/// the actual course and speed relative to the ground
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, PartialEq, Clone)]
 pub struct VTG {
     /// Navigational system.


### PR DESCRIPTION
Adds optional support for `defmt`, which makes debugging embedded firmware that uses this package easier.